### PR TITLE
Feature/docker builder module

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 indent_style = space
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
-      - name: Ckecing formating of all files
+      - name: Checking formating of all files
         run: |
           terraform fmt -check -diff -recursive
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This repo list some open to use Terraform modules we use at `Peak AI` because we
 - AWS
     - [:open_file_folder: S3](/s3)
     - [:camera: ECR](/ecr)
+    - [:construction: Docker Builder](/docker_builder)
 - Miscellaneous
     - [:bookmark: Tags (aka Labels)](/tags)
-    - [:construction: Docker Builder](/docker_builder)
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This repo list some open to use Terraform modules we use at `Peak AI` because we
 - AWS
     - [:open_file_folder: S3](/s3)
     - [:camera: ECR](/ecr)
-- Misclleneous
+- Miscellaneous
     - [:bookmark: Tags (aka Labels)](/tags)
+    - [:construction: Docker Builder](/docker_builder)
 
 ## Example usage
 

--- a/docker_builder/README.md
+++ b/docker_builder/README.md
@@ -1,4 +1,4 @@
-# :construction: Docker Builder
+# :construction: Builds Docker Image as Part of Infra and pushes to ECR
 
 ## Gist
 

--- a/docker_builder/README.md
+++ b/docker_builder/README.md
@@ -1,4 +1,4 @@
-# Docker Builder
+# :construction: Docker Builder
 
 ## Gist
 

--- a/docker_builder/README.md
+++ b/docker_builder/README.md
@@ -27,8 +27,7 @@ locals {
 module "my_docker_builder" {
   source     = "git::https://github.com/peak-ai/terraform-modules.git//docker_builder?ref=v0.4.0"
   # Here we use the repo which has been created in the basic example. (If you were doing this, you wouldnt hard code these values)
-  repository = "<account_id>.dkr.ecr.<region>.amazonaws.com"
-  service    = "latest-my-example"
+  repository_url = "<account_id>.dkr.ecr.<region>.amazonaws.com/latest-my-example"
   dockerfile = "./Dockerfile"
   args       = ["--build-arg NPM_TOKEN=${local.npm_token}"]
 }

--- a/docker_builder/README.md
+++ b/docker_builder/README.md
@@ -27,7 +27,7 @@ locals {
 module "my_docker_builder" {
   source     = "git::https://github.com/peak-ai/terraform-modules.git//docker_builder?ref=v0.4.0"
   # Here we use the repo which has been created in the basic example. (If you were doing this, you wouldnt hard code these values)
-  repository = "122403041129.dkr.ecr.eu-west-1.amazonaws.com"
+  repository = "<account_id>.dkr.ecr.<region>.amazonaws.com"
   service    = "latest-my-example"
   dockerfile = "./Dockerfile"
   args       = ["--build-arg NPM_TOKEN=${local.npm_token}"]

--- a/docker_builder/README.md
+++ b/docker_builder/README.md
@@ -1,0 +1,35 @@
+# Docker Builder
+
+## Gist
+
+This module allows you to build a docker image as part of the terraform deployment, which can then be used as part of other
+infrastructure, for example deploying to kubernetes, or to ECS or beanstalk.
+
+This is good because it allows us to make use of environment variables and other configs which are already part of our terraform
+infrastructure deployment. You'll be able to provision infrastructure, build a docker image and deploy the docker image in one command
+rather than a series of commands, which is what you'd traditionally have to do in CodePipeline or CodeBuild.
+
+## Example usage
+
+```hcl
+provider "aws" {
+  version = "~> 2.62"
+}
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+locals {
+  npm_token = "123"
+}
+
+module "my_docker_builder" {
+  source     = "git::https://github.com/peak-ai/terraform-modules.git//docker_builder?ref=v0.4.0"
+  # Here we use the repo which has been created in the basic example. (If you were doing this, you wouldnt hard code these values)
+  repository = "122403041129.dkr.ecr.eu-west-1.amazonaws.com"
+  service    = "latest-my-example"
+  dockerfile = "./Dockerfile"
+  args       = ["--build-arg NPM_TOKEN=${local.npm_token}"]
+}
+```

--- a/docker_builder/main.tf
+++ b/docker_builder/main.tf
@@ -1,25 +1,25 @@
 terraform {
   required_providers {
     null = "~> 2.1"
-    aws = ">= 2.62"
+    aws  = ">= 2.62"
   }
 }
 
 module "git_branch" {
-  source = "matti/resource/shell"
+  source  = "matti/resource/shell"
   command = "git rev-parse --abbrev-ref HEAD"
 }
 
 module "git_sha" {
-  source = "matti/resource/shell"
+  source  = "matti/resource/shell"
   command = "git rev-parse HEAD"
 }
 
 locals {
-  registry = "${var.repository}/${var.service}"
-  args = join(" ", var.args)
+  registry   = "${var.repository}/${var.service}"
+  args       = join(" ", var.args)
   git_branch = lower(replace(module.git_branch.stdout, "/", "-"))
-  git_sha = module.git_sha.stdout
+  git_sha    = module.git_sha.stdout
 }
 
 resource "null_resource" "build_image" {

--- a/docker_builder/main.tf
+++ b/docker_builder/main.tf
@@ -29,7 +29,11 @@ resource "null_resource" "build_image" {
 
   provisioner "local-exec" {
     command = <<EOT
-      eval $(aws ecr get-login --no-include-email);
+      aws ecr get-login-password \
+        --region ${var.region} \
+        | docker login \
+        --username AWS \
+        --password-stdin ${aws_ecr_repository.image_repo.repository_url};
 
       docker pull ${local.registry}:${local.git_branch} || true;
       docker build \

--- a/docker_builder/main.tf
+++ b/docker_builder/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    null = "~> 2.1"
+    aws = ">= 2.62"
+  }
+}
+
+module "git_branch" {
+  source = "matti/resource/shell"
+  command = "git rev-parse --abbrev-ref HEAD"
+}
+
+module "git_sha" {
+  source = "matti/resource/shell"
+  command = "git rev-parse HEAD"
+}
+
+locals {
+  registry = "${var.repository}/${var.service}"
+  args = join(" ", var.args)
+  git_branch = lower(replace(module.git_branch.stdout, "/", "-"))
+  git_sha = module.git_sha.stdout
+}
+
+resource "null_resource" "build_image" {
+  triggers = {
+    image_tag = module.git_sha.stdout
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      eval $(aws ecr get-login --no-include-email);
+
+      docker pull ${local.registry}:${local.git_branch} || true;
+      docker build \
+        --cache-from ${local.registry}:${local.git_branch} \
+        --tag ${local.registry}:${local.git_branch} \
+        --tag ${local.registry}:${local.git_sha} \
+        --build-arg CI="true" \
+        ${local.args} ${var.dockerfile};
+      docker push ${local.registry}:${local.git_branch};
+      docker push ${local.registry}:${local.git_sha};
+    EOT
+  }
+}

--- a/docker_builder/main.tf
+++ b/docker_builder/main.tf
@@ -16,10 +16,12 @@ module "git_sha" {
 }
 
 locals {
-  registry   = "${var.repository}/${var.service}"
   args       = join(" ", var.args)
   git_branch = lower(replace(module.git_branch.stdout, "/", "-"))
   git_sha    = module.git_sha.stdout
+
+  tag = "${var.repository_url}:${local.git_branch}"
+  extra_tags = local.git_branch == "master" ? ["${var.repository_url}:${local.git_sha}", "${var.repository_url}:latest"] : ["${var.repository_url}:${local.git_sha}"]
 }
 
 resource "null_resource" "build_image" {
@@ -33,17 +35,20 @@ resource "null_resource" "build_image" {
         --region ${var.region} \
         | docker login \
         --username AWS \
-        --password-stdin ${aws_ecr_repository.image_repo.repository_url};
+        --password-stdin ${var.repository_url};
 
-      docker pull ${local.registry}:${local.git_branch} || true;
+      docker pull ${local.tag} || true;
       docker build \
-        --cache-from ${local.registry}:${local.git_branch} \
-        --tag ${local.registry}:${local.git_branch} \
-        --tag ${local.registry}:${local.git_sha} \
+        --cache-from ${local.tag} \
+        --tag ${local.tag} \
         --build-arg CI="true" \
         ${local.args} ${var.dockerfile};
-      docker push ${local.registry}:${local.git_branch};
-      docker push ${local.registry}:${local.git_sha};
+      docker push ${local.tag};
+
+      %{ for tag in local.extra_tags }
+        docker tag ${local.tag} ${tag}
+        docker push ${tag}
+      %{ endfor }
     EOT
   }
 }

--- a/docker_builder/outputs.tf
+++ b/docker_builder/outputs.tf
@@ -1,4 +1,9 @@
 output "image" {
-  value       = "${local.registry}:${module.git_sha.stdout}"
+  value       = "${var.repository_url}:${module.git_sha.stdout}"
   description = "The full path to the docker image"
+}
+
+output "tags" {
+  value       = coalesce(local.tag, local.extra_tags...)
+  description = "The image tags that have been built"
 }

--- a/docker_builder/outputs.tf
+++ b/docker_builder/outputs.tf
@@ -1,0 +1,4 @@
+output "image" {
+  value       = "${local.registry}:${module.git_sha.stdout}"
+  description = "The full path to the docker image"
+}

--- a/docker_builder/variables.tf
+++ b/docker_builder/variables.tf
@@ -1,0 +1,21 @@
+variable "repository" {
+  type        = string
+  description = "URL of the ECR repository"
+}
+
+variable "service" {
+  type        = string
+  description = "Name of the service"
+}
+
+variable "dockerfile" {
+  type        = string
+  description = "Location of Dockerfile"
+}
+
+variable "args" {
+  type        = list(string)
+  description = "A key value list of additional arguments to be passed into the docker build"
+  default     = []
+}
+

--- a/docker_builder/variables.tf
+++ b/docker_builder/variables.tf
@@ -1,11 +1,11 @@
-variable "repository" {
+variable "repository_url" {
   type        = string
   description = "URL of the ECR repository"
 }
 
-variable "service" {
+variable "region" {
   type        = string
-  description = "Name of the service"
+  description = "The AWS region to use"
 }
 
 variable "dockerfile" {


### PR DESCRIPTION
# Description

Added a module to easily build docker images as part of the terraform deployment stage, which can then be directly used in other infrastructure, such as K8S or ECS deployments. This means we don't need to have separate tasks to build docker images and then pass the image URL into terraform, we can just use a terraform apply to build and deploy.

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation

# Steps to test
1. Checkout example code in private repo
2. Run example code
