### PR TITLE
Pass in git options for docker build

### DIFF
--- a/docker_builder/main.tf
+++ b/docker_builder/main.tf
@@ -5,28 +5,17 @@ terraform {
   }
 }
 
-module "git_branch" {
-  source  = "matti/resource/shell"
-  command = "git rev-parse --abbrev-ref HEAD"
-}
-
-module "git_sha" {
-  source  = "matti/resource/shell"
-  command = "git rev-parse HEAD"
-}
-
 locals {
   args       = join(" ", var.args)
-  git_branch = lower(replace(module.git_branch.stdout, "/", "-"))
-  git_sha    = module.git_sha.stdout
+  git_branch = lower(replace(var.git_branch, "/", "-"))
 
   tag        = "${var.repository_url}:${local.git_branch}"
-  extra_tags = local.git_branch == "master" ? ["${var.repository_url}:${local.git_sha}", "${var.repository_url}:latest"] : ["${var.repository_url}:${local.git_sha}"]
+  extra_tags = local.git_branch == "master" ? ["${var.repository_url}:${var.git_sha}", "${var.repository_url}:latest"] : ["${var.repository_url}:${var.git_sha}"]
 }
 
 resource "null_resource" "build_image" {
   triggers = {
-    image_tag = module.git_sha.stdout
+    image_tag = var.git_sha
   }
 
   provisioner "local-exec" {
@@ -42,7 +31,7 @@ resource "null_resource" "build_image" {
         --cache-from ${local.tag} \
         --tag ${local.tag} \
         --build-arg CI="true" \
-        ${local.args} ${var.dockerfile};
+        ${local.args} ${var.path};
       docker push ${local.tag};
 
       %{for tag in local.extra_tags}

--- a/docker_builder/outputs.tf
+++ b/docker_builder/outputs.tf
@@ -1,5 +1,5 @@
 output "image" {
-  value       = "${var.repository_url}:${module.git_sha.stdout}"
+  value       = "${var.repository_url}:${var.git_sha}"
   description = "The full path to the docker image"
 }
 

--- a/docker_builder/variables.tf
+++ b/docker_builder/variables.tf
@@ -8,14 +8,24 @@ variable "region" {
   description = "The AWS region to use"
 }
 
-variable "dockerfile" {
+variable "path" {
   type        = string
-  description = "Location of Dockerfile"
+  description = "Path where the dockerfile exists"
 }
 
 variable "args" {
   type        = list(string)
   description = "A key value list of additional arguments to be passed into the docker build"
   default     = []
+}
+
+variable "git_branch" {
+  type        = string
+  description = "The git branch"
+}
+
+variable "git_sha" {
+  type        = string
+  description = "The SHA of the git commit"
 }
 


### PR DESCRIPTION
# Description

This doesn't actually work in Github Actions, it seems to be because of how it's checking out the repo.
So I've refactoring out the shell module, should be able to pass in these values from CI.

Changed Dockerfile to path, as it should be a folder not an explicit pathname.

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation

# Steps to test
I've updated the example in the terraform repo with a working example.
