### PR TITLE
Removed experiments to work with new terraform version

### DIFF
--- a/tags/variables.tf
+++ b/tags/variables.tf
@@ -1,8 +1,3 @@
-terraform {
-  # This is enabled to use validation in variable
-  experiments = [variable_validation]
-}
-
 variable "stage" {
   description = "Stage on which infra should be deployed"
   type        = string


### PR DESCRIPTION
# Description
 `experiments = [variable_validation]` as it breaks with `Terraform v0.13.0` which has this inbuilt and when set explicitly, gives error 
```shell
Error: Experiment has concluded

  on .terraform/modules/tags/tags/variables.tf line 3, in terraform:
   3:   experiments = [variable_validation]

Experiment "variable_validation" is no longer available. Custom variable
validation can now be used by default, without enabling an experiment.
```

_Description of what this PR does. What have you added or changed, and why?_

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation

# Steps to test
1. Try terraform init on an infra with `tags` modules used along with Terraform CLI v0.13.0
